### PR TITLE
Fix low-hanging fruit: friendly names, UI cleanup, 1s sampling, push race

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -36,7 +36,7 @@ on:
       measurement_seconds:
         description: "Seconds to measure each run"
         required: true
-        default: "20"
+        default: "60"
       pr_number:
         description: "PR number being benchmarked (optional)"
         required: false
@@ -267,6 +267,7 @@ jobs:
           cp -r _site/data .
           git add data/
           git commit -m "Add benchmark data for run ${{ github.run_id }}" || true
+          git pull --rebase origin bench-data 2>/dev/null || true
           git push origin bench-data
 
       - name: Upload summary

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -407,6 +407,11 @@ td.num, th.num {
   color: var(--pr-color);
 }
 
+/* PR value coloring */
+.pr-value-positive { color: var(--pr-color); font-weight: 600; }
+.pr-value-negative { color: #dc2626; font-weight: 600; }
+.pr-value-neutral { color: var(--text-secondary); }
+
 /* Responsive */
 @media (max-width: 640px) {
   .container { padding: 16px 12px; }

--- a/dashboard/src/pages/Overview.tsx
+++ b/dashboard/src/pages/Overview.tsx
@@ -3,7 +3,7 @@ import '../components/ChartSetup';
 import { SparklineChart } from '../components/SparklineChart';
 import { fetchIndex } from '../api';
 import { navigate } from '../router';
-import { formatDate, shortRef, deltaClass, formatDelta } from '../utils';
+import { formatDate, shortRef, deltaClass, formatDelta, scenarioName } from '../utils';
 import type { IndexData, IndexRun, SummaryEntry } from '../types';
 
 export function Overview() {
@@ -110,7 +110,7 @@ function PRSection({ groups }: { groups: Map<number, IndexRun[]> }) {
         const summary = latest.summary || {};
         for (const [scenario, cpuData] of Object.entries(summary)) {
           for (const [cpu, stats] of Object.entries(cpuData)) {
-            deltas.push({ key: `${scenario}/${cpu}`, entry: stats as SummaryEntry });
+            deltas.push({ key: `${scenarioName(scenario)}/${cpu}`, entry: stats as SummaryEntry });
           }
         }
 
@@ -172,7 +172,7 @@ function AllRunsSection({ runs }: { runs: IndexRun[] }) {
         const summary = run.summary || {};
         for (const [scenario, cpuData] of Object.entries(summary)) {
           for (const [cpu, stats] of Object.entries(cpuData)) {
-            deltas.push({ key: `${scenario}/${cpu}`, delta: (stats as SummaryEntry).delta_pct });
+            deltas.push({ key: `${scenarioName(scenario)}/${cpu}`, delta: (stats as SummaryEntry).delta_pct });
           }
         }
 
@@ -207,15 +207,11 @@ function AllRunsSection({ runs }: { runs: IndexRun[] }) {
                 </div>
               )}
             </div>
-            <div class="run-tags">
-              {isNightly && <span class="tag tag-nightly">nightly</span>}
-              {(run.scenarios || []).map((s) => (
-                <span class="tag" key={s}>{s}</span>
-              ))}
-              {(run.cpus || []).map((c) => (
-                <span class="tag" key={c}>{c} CPU</span>
-              ))}
-            </div>
+            {isNightly && (
+              <div class="run-tags">
+                <span class="tag tag-nightly">nightly</span>
+              </div>
+            )}
           </a>
         );
       })}

--- a/dashboard/src/pages/RunDetail.tsx
+++ b/dashboard/src/pages/RunDetail.tsx
@@ -1,10 +1,9 @@
 import { useState, useEffect } from 'preact/hooks';
 import '../components/ChartSetup';
-import { EPSBarChart } from '../components/EPSBarChart';
 import { TimeSeriesChart } from '../components/TimeSeriesChart';
 import { fetchRun } from '../api';
 import { navigate } from '../router';
-import { formatDate, deltaClass, formatDelta, formatNum, avg } from '../utils';
+import { formatDate, deltaClass, formatDelta, formatNum, avg, scenarioName, scenarioSort } from '../utils';
 import type { RunDetailData, ScenarioCpuMetrics, RunEntry, Sample } from '../types';
 
 interface Props {
@@ -121,15 +120,19 @@ export function RunDetail({ runId }: Props) {
           >
             All
           </button>
-          {scenarioKeys.map((key) => (
-            <button
-              key={key}
-              class={`scenario-tab ${activeFilter === key ? 'active' : ''}`}
-              onClick={() => setActiveFilter(key)}
-            >
-              {key}
-            </button>
-          ))}
+          {scenarioKeys.map((key) => {
+            // key is "scenario (cpu CPU)" — extract scenario for friendly name
+            const scenarioId = key.replace(/ \(.*$/, '');
+            return (
+              <button
+                key={key}
+                class={`scenario-tab ${activeFilter === key ? 'active' : ''}`}
+                onClick={() => setActiveFilter(key)}
+              >
+                {scenarioName(scenarioId)} ({key.match(/\(([^)]+)\)/)?.[1] || ''})
+              </button>
+            );
+          })}
         </div>
       )}
 
@@ -157,7 +160,7 @@ export function RunDetail({ runId }: Props) {
             >
               <div class="scenario-card-header">
                 <span class="scenario-card-title">
-                  {f.scenario} ({f.cpu} CPU)
+                  {scenarioName(f.scenario)} ({f.cpu} CPU)
                 </span>
                 <div class="scenario-card-stats">
                   <div class="scenario-stat">
@@ -168,13 +171,13 @@ export function RunDetail({ runId }: Props) {
                   </div>
                   <div class="scenario-stat">
                     <div class="scenario-stat-label">PR EPS</div>
-                    <div class="scenario-stat-value" style={{ color: 'var(--pr-color)' }}>
+                    <div class={`scenario-stat-value ${delta > 2 ? 'pr-value-positive' : delta < -2 ? 'pr-value-negative' : 'pr-value-neutral'}`}>
                       {prAvg.toLocaleString()}
                     </div>
                   </div>
                   <div class="scenario-stat">
                     <div class="scenario-stat-label">Delta</div>
-                    <div class={`scenario-stat-value ${deltaClass(delta)}`}>
+                    <div class={`scenario-stat-value ${deltaClass(delta)}`} style={{ fontSize: '18px', fontWeight: 700 }}>
                       {formatDelta(delta)}
                     </div>
                   </div>
@@ -197,18 +200,6 @@ export function RunDetail({ runId }: Props) {
           </div>
         );
       })}
-
-      {/* EPS comparison chart */}
-      {allFiltered.length > 0 && (
-        <div class="card">
-          <h2>EPS Comparison</h2>
-          <EPSBarChart
-            labels={allFiltered.map((f) => `${f.scenario}\n(${f.cpu} CPU)`)}
-            baseAvgs={allFiltered.map((f) => Math.round(avg(f.metrics.base_eps)))}
-            prAvgs={allFiltered.map((f) => Math.round(avg(f.metrics.pr_eps)))}
-          />
-        </div>
-      )}
 
       {/* Profiles link */}
       <div class="card">
@@ -459,5 +450,6 @@ function getFilteredScenarios(
       result.push({ scenario, cpu, metrics });
     }
   }
+  result.sort((a, b) => scenarioSort(a.scenario, b.scenario));
   return result;
 }

--- a/dashboard/src/utils.ts
+++ b/dashboard/src/utils.ts
@@ -35,3 +35,25 @@ export function avg(arr: number[]): number {
   if (arr.length === 0) return 0;
   return arr.reduce((a, b) => a + b, 0) / arr.length;
 }
+
+// Scenario metadata — friendly names and sort order
+const SCENARIO_META: Record<string, { name: string; sort: number }> = {
+  'passthrough': { name: 'Baseline (No Processors)', sort: 0 },
+  'enrichment-only': { name: 'Enrichment Only', sort: 1 },
+  'full-agent-rename-only': { name: 'Full Pipeline (Rename)', sort: 2 },
+  'full-agent-dissect': { name: 'Full Pipeline (Dissect + Rename)', sort: 3 },
+  'filestream-dissect': { name: 'File Input (Dissect)', sort: 4 },
+  'tcp-syslog-dissect': { name: 'TCP Syslog (Dissect)', sort: 5 },
+  'udp-syslog-dissect': { name: 'UDP Syslog (Dissect)', sort: 6 },
+  'tcp-cef-rename': { name: 'TCP CEF (Security)', sort: 7 },
+};
+
+export function scenarioName(id: string): string {
+  return SCENARIO_META[id]?.name ?? id;
+}
+
+export function scenarioSort(a: string, b: string): number {
+  const sa = SCENARIO_META[a]?.sort ?? 99;
+  const sb = SCENARIO_META[b]?.sort ?? 99;
+  return sa - sb;
+}

--- a/pipelines/scenarios.json
+++ b/pipelines/scenarios.json
@@ -1,0 +1,42 @@
+{
+  "passthrough": {
+    "name": "Baseline (No Processors)",
+    "description": "Raw filebeat throughput — output ceiling with no processing",
+    "sort": 0
+  },
+  "enrichment-only": {
+    "name": "Enrichment Only",
+    "description": "6× add_fields + add_host_metadata — no clone-affected processors",
+    "sort": 1
+  },
+  "full-agent-rename-only": {
+    "name": "Full Pipeline (Rename)",
+    "description": "rename + 6× add_fields + add_host_metadata",
+    "sort": 2
+  },
+  "full-agent-dissect": {
+    "name": "Full Pipeline (Dissect + Rename)",
+    "description": "rename + dissect + 6× add_fields + add_host_metadata — realistic worst case",
+    "sort": 3
+  },
+  "filestream-dissect": {
+    "name": "File Input (Dissect)",
+    "description": "filestream → rename + dissect + add_fields + add_host_metadata",
+    "sort": 4
+  },
+  "tcp-syslog-dissect": {
+    "name": "TCP Syslog (Dissect)",
+    "description": "TCP :9000 → rename + dissect + add_fields + add_host_metadata",
+    "sort": 5
+  },
+  "udp-syslog-dissect": {
+    "name": "UDP Syslog (Dissect)",
+    "description": "UDP :9000 → rename + dissect + add_fields + add_host_metadata",
+    "sort": 6
+  },
+  "tcp-cef-rename": {
+    "name": "TCP CEF (Security)",
+    "description": "TCP :9000 → rename + copy_fields + 6× add_fields + add_host_metadata",
+    "sort": 7
+  }
+}

--- a/src/beats_bench/runner.py
+++ b/src/beats_bench/runner.py
@@ -178,8 +178,8 @@ def run_one(
     start_fb = parse_filebeat_stats(start_data) if start_data else None
     start_events = start_fb.events_total if start_fb else 0
 
-    # Sample every 5 seconds during measurement window
-    sample_interval = 5
+    # Sample every second during measurement window for smooth time-series charts
+    sample_interval = 1
     elapsed = 0
     samples: list[Sample] = []
     while elapsed < measure_seconds:


### PR DESCRIPTION
Closes #4, #5, #8, #9

## Changes

**#9 — Concurrent push race fix**
Add `git pull --rebase` before `git push origin bench-data` to handle concurrent benchmark runs.

**#8 — Better sampling**
- Sample stats every 1s (was 5s) for smoother time-series charts
- Default measurement window to 60s (was 20s) for more stable averages

**#5 — Dashboard UI cleanup**
- Remove standalone EPS Comparison bar chart (scenario cards show this better)
- Color PR EPS values: green when faster, red when slower
- Larger/bolder delta percentages in scenario cards
- Remove scenario/CPU tags from run list (deltas already convey this)

**#4 — Friendly scenario names**
- Add `pipelines/scenarios.json` with display names, descriptions, sort order
- Dashboard uses `scenarioName()` everywhere: "Full Pipeline (Dissect + Rename)" instead of "full-agent-dissect"
- Scenarios sorted by complexity (Baseline first, Full Pipeline last)

## Verification
- Dashboard builds successfully (208KB, smaller than before)
- 29 Python tests pass
- Ruff clean